### PR TITLE
Fix node 12 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,6 @@
     "type": "git",
     "url": "git://github.com/ripple/ripple-binary-codec.git"
   },
-  "engines": {
-    "node": ">=10.0.0 <11.0.0"
-  },
   "bugs": {
     "url": "https://github.com/ripple/ripple-binary-codec/issues"
   },

--- a/test/binary-parser-test.js
+++ b/test/binary-parser-test.js
@@ -27,9 +27,9 @@ function basicApiTests() {
     assert(parser._buf instanceof Uint8Array);
     const read1 = parser.read(1);
     assert(read1 instanceof Uint8Array);
-    assert.deepEqual(read1, [0]);
-    assert.deepEqual(parser.read(4), [1, 2, 3, 4]);
-    assert.deepEqual(parser.read(2), [5, 6]);
+    assert.deepEqual(read1, Uint8Array.from([0]));
+    assert.deepEqual(parser.read(4), Uint8Array.from([1, 2, 3, 4]));
+    assert.deepEqual(parser.read(2), Uint8Array.from([5, 6]));
     assert.throws(() => parser.read(1));
   });
   it('can read a Uint32 at full', () => {

--- a/test/binary-serializer-test.js
+++ b/test/binary-serializer-test.js
@@ -62,7 +62,7 @@ function bytesListTest() {
   it('can join all arrays into one via toBytes', function() {
     const joined = list.toBytes();
     assert(joined.length, 5);
-    assert.deepEqual(joined, [0, 2, 3, 4, 5]);
+    assert.deepEqual(joined, Uint8Array.from([0, 2, 3, 4, 5]));
   });
 }
 
@@ -95,7 +95,7 @@ function UIntTest() {
         return;
       }
       serializer.writeType(type, n);
-      assert.deepEqual(bl.toBytes(), expected);
+      assert.deepEqual(bl.toBytes(), Uint8Array.from(expected));
     });
   }
 

--- a/test/bytes-utils-test.js
+++ b/test/bytes-utils-test.js
@@ -12,12 +12,12 @@ describe('bytes-utils', function() {
     it('can decode hex to a Uint8Array', function() {
       const result = parseBytes('0012', Uint8Array);
       assert(result instanceof Uint8Array);
-      assert.deepEqual(result, [0x00, 0x12]);
+      assert.deepEqual(result, Uint8Array.from([0x00, 0x12]));
     });
     it('can convert a list to a Uint8Array', function() {
       const result = parseBytes([0x00, 0x12], Uint8Array);
       assert(result instanceof Uint8Array);
-      assert.deepEqual(result, [0x00, 0x12]);
+      assert.deepEqual(result, Uint8Array.from([0x00, 0x12]));
     });
     it('can decode hex to a Buffer', function() {
       const result = parseBytes('0012', Buffer);
@@ -66,7 +66,7 @@ describe('bytes-utils', function() {
     });
     it('the 4th arg is the output class type', function() {
       assert.deepEqual(slice(val, 2, 4, Buffer).toJSON().data, [3, 4]);
-      assert.deepEqual(slice(val, 2, 4, Uint8Array), [3, 4]);
+      assert.deepEqual(slice(val, 2, 4, Uint8Array), Uint8Array.from([3, 4]));
     });
   });
 });


### PR DESCRIPTION
The unit tests were comparing things of different types, which failed under the stricter checks.