### PR TITLE
Support encoding and decoding of NegativeUNL pseudo-transactions

### DIFF
--- a/src/enums/definitions.json
+++ b/src/enums/definitions.json
@@ -40,7 +40,8 @@
     "Check": 67,
     "Nickname": 110,
     "Contract": 99,
-    "GeneratorMap": 103
+    "GeneratorMap": 103,
+    "NegativeUNL": 78
   },
   "FIELDS": [
     [
@@ -1024,6 +1025,36 @@
       }
     ],
     [
+      "UNLModifyValidator",
+      {
+        "nth": 19,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Blob"
+      }
+    ],
+    [
+      "ValidatorToDisable",
+      {
+        "nth": 20,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Blob"
+      }
+    ],
+    [
+      "ValidatorToReEnable",
+      {
+        "nth": 20,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Blob"
+      }
+    ],
+    [
       "Account",
       {
         "nth": 1,
@@ -1234,6 +1265,16 @@
       }
     ],
     [
+      "DisabledValidator",
+      {
+        "nth": 19,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
       "ArrayEndMarker",
       {
         "nth": 1,
@@ -1317,6 +1358,16 @@
       "Majorities",
       {
         "nth": 16,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STArray"
+      }
+    ],
+    [
+      "NegativeUNL",
+      {
+        "nth": 17,
         "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
@@ -1484,6 +1535,16 @@
       }
     ],
     [
+      "BeginLedgerSeq",
+      {
+        "nth": 40,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
       "Channel",
       {
         "nth": 22,
@@ -1517,6 +1578,16 @@
       "TickSize",
       {
         "nth": 16,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "UNLModifyDisabling",
+      {
+        "nth": 17,
         "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
@@ -1685,6 +1756,7 @@
     "AccountDelete": 21,
 
     "EnableAmendment": 100,
-    "SetFee": 101
+    "SetFee": 101,
+    "UNLModify": 102
   }
 }

--- a/src/enums/definitions.json
+++ b/src/enums/definitions.json
@@ -1365,7 +1365,7 @@
       }
     ],
     [
-      "NegativeUNL",
+      "DisabledValidators",
       {
         "nth": 17,
         "isVLEncoded": false,

--- a/src/types/account-id.ts
+++ b/src/types/account-id.ts
@@ -1,8 +1,4 @@
-import {
-  decodeAccountID,
-  encodeAccountID,
-  isValidClassicAddress,
-} from "ripple-address-codec";
+import { decodeAccountID, encodeAccountID } from "ripple-address-codec";
 import { Hash160 } from "./hash-160";
 
 /**
@@ -46,10 +42,6 @@ class AccountID extends Hash160 {
    * @returns an AccountID object
    */
   static fromBase58(value: string): AccountID {
-    if (!isValidClassicAddress(value)) {
-      throw new Error("Invalid Classic address");
-    }
-
     return new AccountID(decodeAccountID(value));
   }
 

--- a/src/types/account-id.ts
+++ b/src/types/account-id.ts
@@ -1,4 +1,8 @@
-import { decodeAccountID, encodeAccountID } from "ripple-address-codec";
+import {
+  decodeAccountID,
+  encodeAccountID,
+  isValidClassicAddress,
+} from "ripple-address-codec";
 import { Hash160 } from "./hash-160";
 
 /**
@@ -7,7 +11,7 @@ import { Hash160 } from "./hash-160";
 class AccountID extends Hash160 {
   static readonly defaultAccountID: AccountID = new AccountID(Buffer.alloc(20));
 
-  constructor(bytes: Buffer) {
+  constructor(bytes?: Buffer) {
     super(bytes ?? AccountID.defaultAccountID.bytes);
   }
 
@@ -23,6 +27,10 @@ class AccountID extends Hash160 {
     }
 
     if (typeof value === "string") {
+      if(value === "") {
+        return new AccountID();
+      }
+
       return /^r/.test(value)
         ? this.fromBase58(value)
         : new AccountID(Buffer.from(value, "hex"));
@@ -38,6 +46,10 @@ class AccountID extends Hash160 {
    * @returns an AccountID object
    */
   static fromBase58(value: string): AccountID {
+    if (!isValidClassicAddress(value)) {
+      throw new Error("Invalid Classic address");
+    }
+
     return new AccountID(decodeAccountID(value));
   }
 

--- a/src/types/account-id.ts
+++ b/src/types/account-id.ts
@@ -27,7 +27,7 @@ class AccountID extends Hash160 {
     }
 
     if (typeof value === "string") {
-      if(value === "") {
+      if (value === "") {
         return new AccountID();
       }
 
@@ -68,8 +68,6 @@ class AccountID extends Hash160 {
    * @returns the base58 string defined by this.bytes
    */
   toBase58(): string {
-    if (this.bytes.byteLength === 0) return "";
-
     return encodeAccountID(this.bytes);
   }
 }

--- a/src/types/hash-160.ts
+++ b/src/types/hash-160.ts
@@ -7,7 +7,11 @@ class Hash160 extends Hash {
   static readonly width = 20;
   static readonly ZERO_160: Hash160 = new Hash160(Buffer.alloc(Hash160.width));
 
-  constructor(bytes: Buffer) {
+  constructor(bytes?: Buffer) {
+    if(bytes && bytes.byteLength === 0) {
+      bytes = Hash160.ZERO_160.bytes;
+    }
+
     super(bytes ?? Hash160.ZERO_160.bytes);
   }
 }

--- a/src/types/hash-160.ts
+++ b/src/types/hash-160.ts
@@ -8,7 +8,7 @@ class Hash160 extends Hash {
   static readonly ZERO_160: Hash160 = new Hash160(Buffer.alloc(Hash160.width));
 
   constructor(bytes?: Buffer) {
-    if(bytes && bytes.byteLength === 0) {
+    if (bytes && bytes.byteLength === 0) {
       bytes = Hash160.ZERO_160.bytes;
     }
 

--- a/src/types/hash.ts
+++ b/src/types/hash.ts
@@ -9,9 +9,7 @@ class Hash extends Comparable {
 
   constructor(bytes: Buffer) {
     super(bytes);
-    if (
-      this.bytes.byteLength !== (this.constructor as typeof Hash).width
-    ) {
+    if (this.bytes.byteLength !== (this.constructor as typeof Hash).width) {
       throw new Error(`Invalid Hash length ${this.bytes.byteLength}`);
     }
   }

--- a/src/types/hash.ts
+++ b/src/types/hash.ts
@@ -9,24 +9,28 @@ class Hash extends Comparable {
 
   constructor(bytes: Buffer) {
     super(bytes);
+    if (
+      this.bytes.byteLength !== (this.constructor as typeof Hash).width
+    ) {
+      throw new Error(`Invalid Hash length ${this.bytes.byteLength}`);
+    }
   }
 
   /**
    * Construct a Hash object from an existing Hash object or a hex-string
    *
    * @param value A hash object or hex-string of a hash
-   */ 
+   */
   static from<T extends Hash | string>(value: T): Hash {
-    if(value instanceof this) {
-      return value
+    if (value instanceof this) {
+      return value;
     }
-    
-    if(typeof value === "string") {
+
+    if (typeof value === "string") {
       return new this(Buffer.from(value, "hex"));
     }
 
     throw new Error("Cannot construct Hash from given value");
-    
   }
 
   /**

--- a/src/types/path-set.ts
+++ b/src/types/path-set.ts
@@ -29,9 +29,10 @@ interface HopObject extends JsonObject {
  * TypeGuard for HopObject
  */
 function isHopObject(arg): arg is HopObject {
-  return (arg.issuer !== undefined ||
-      arg.account !== undefined ||
-      arg.currency !== undefined
+  return (
+    arg.issuer !== undefined ||
+    arg.account !== undefined ||
+    arg.currency !== undefined
   );
 }
 
@@ -40,9 +41,9 @@ function isHopObject(arg): arg is HopObject {
  */
 function isPathSet(arg): arg is Array<Array<HopObject>> {
   return (
-    Array.isArray(arg) && arg.length === 0 ||
-    Array.isArray(arg) && Array.isArray(arg[0]) && arg[0].length === 0 ||
-    Array.isArray(arg) && Array.isArray(arg[0]) && isHopObject(arg[0][0])
+    (Array.isArray(arg) && arg.length === 0) ||
+    (Array.isArray(arg) && Array.isArray(arg[0]) && arg[0].length === 0) ||
+    (Array.isArray(arg) && Array.isArray(arg[0]) && isHopObject(arg[0][0]))
   );
 }
 

--- a/test/binary-serializer.test.js
+++ b/test/binary-serializer.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable func-style */
 
 const { binary } = require('../dist/coretypes')
-const { encode } = require('../dist')
+const { encode, decode } = require('../dist')
 const { makeParser, BytesList, BinarySerializer } = binary
 const { coreTypes } = require('../dist/types')
 const { UInt8, UInt16, UInt32, UInt64, STObject } = coreTypes
@@ -49,6 +49,8 @@ const PaymentChannel = {
     binary: require('./fixtures/payment-channel-claim-binary.json')
   }
 }
+
+const NegativeUNL = require('./fixtures/negative-unl.json');
 
 function bytesListTest () {
   const list = new BytesList().put(Buffer.from([0])).put(Buffer.from([2, 3])).put(Buffer.from([4, 5]))
@@ -171,6 +173,15 @@ function PaymentChannelTest () {
   })
 }
 
+function NegativeUNLTest () {
+  test('can serialize NegativeUNL', () => {
+    expect(encode(NegativeUNL.tx)).toEqual(NegativeUNL.binary);
+  })
+  test('can deserialize NegativeUNL', () => {
+    expect(decode(NegativeUNL.binary)).toEqual(NegativeUNL.tx);
+  })
+}
+
 describe('Binary Serialization', function() {
   describe('nestedObjectTests', nestedObjectTests);
   describe('BytesList', bytesListTest);
@@ -179,4 +190,5 @@ describe('Binary Serialization', function() {
   describe('SignerListSet', SignerListSetTest);
   describe('Escrow', EscrowTest);
   describe('PaymentChannel', PaymentChannelTest);
+  describe('NegativeUNLTest', NegativeUNLTest);
 })

--- a/test/fixtures/negative-unl.json
+++ b/test/fixtures/negative-unl.json
@@ -1,0 +1,12 @@
+{
+    "binary": "120066240000000026000003006840000000000000007300701321ED9D593004CC501CACD261BD8E31E863F2B3F6CA69505E7FD54DA8F5690BEFB7AE8114000000000000000000000000000000000000000000101101",
+    "tx": {
+        "UNLModifyDisabling": 1,
+        "LedgerSequence": 768,
+        "UNLModifyValidator": "ED9D593004CC501CACD261BD8E31E863F2B3F6CA69505E7FD54DA8F5690BEFB7AE",
+        "TransactionType": "UNLModify",
+        "Account": "rrrrrrrrrrrrrrrrrrrrrhoLvTp",
+        "Sequence": 0,
+        "Fee": "0",
+        "SigningPubKey": ""}
+}

--- a/test/pseudo-transaction.test.js
+++ b/test/pseudo-transaction.test.js
@@ -1,0 +1,37 @@
+const { encode, decode } = require('../dist')
+
+let json = {
+    "Account": "rrrrrrrrrrrrrrrrrrrrrhoLvTp",
+    "Sequence": 0,
+    "Fee": "0",
+    "SigningPubKey": "",
+    "Signature": ""
+}
+
+let json_blank_acct = {
+    "Account": "",
+    "Sequence": 0,
+    "Fee": "0",
+    "SigningPubKey": "",
+    "Signature": ""
+}
+
+let binary = "24000000006840000000000000007300760081140000000000000000000000000000000000000000"
+
+describe("Can encode Pseudo Transactions", () => {
+    test("Correctly encodes Pseudo Transaciton", () => {
+        expect(encode(json)).toEqual(binary);
+    })
+
+    test("Can decode account objects", () => {
+        expect(decode(encode(json))).toEqual(json);
+    })
+
+    test("Blank AccountID is ACCOUNT_ZERO", () => {
+        expect(encode(json_blank_acct)).toEqual(binary)
+    })
+
+    test("Decodes Blank AccountID", () => {
+        expect(decode(encode(json_blank_acct))).toEqual(json);
+    })
+})


### PR DESCRIPTION
## High Level Overview of Change
Modified `definitions.json` to support encoding and decoding `NegativeUNL`.

### Context of Change
`NegativeUNL` will be released soon, and `ripple-binary-codec` must support `NegativeUNL` transactions. Added fields `UNLModifyValidator`, `ValidatorToDisable`, `ValidatorToReEnable`, `DisabledValidator`, `NegativeUNL`, and `UNLModifyDisabling`.  Added transaction type `UNLModify`. Added Ledger Entry Type `NegativeUNL`.

In addition modified some verification for invalid addresses and Hash lengths to allow for pseudo-transactions.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan
Added two tests, one for encoding, one for decoding, and generated the encoded hex-string from Peng's nUnl rippled branch. 