### PR TITLE
Configure Prettier with semi: true

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
   },
   "homepage": "https://github.com/ripple/ripple-binary-codec#readme",
   "license": "ISC",
-  "readmeFilename": "README.md"
+  "readmeFilename": "README.md",
+  "prettier": {
+    "semi": true
+  }
 }


### PR DESCRIPTION
Without this change, if you run `yarn run lint`, semicolons will be removed.

This PR adds a config option that enables semicolons, which is the way that the code is already written.