### PR TITLE
Add tests for parsing lower-case hex-strings

### DIFF
--- a/src/types/amount.ts
+++ b/src/types/amount.ts
@@ -161,7 +161,7 @@ class Amount extends SerializedType {
 
       return {
         value: value.toString(),
-        currency: currency.toJSON(), 
+        currency: currency.toJSON(),
         issuer: issuer.toJSON(),
       };
     }

--- a/src/types/path-set.ts
+++ b/src/types/path-set.ts
@@ -116,7 +116,9 @@ class Hop extends SerializedType {
     const hopParser = new BinaryParser(this.bytes.toString("hex"));
     const type = hopParser.readUInt8();
 
-    let account, currency, issuer: string | undefined = undefined
+    let account,
+      currency,
+      issuer: string | undefined = undefined;
     if (type & TYPE_ACCOUNT) {
       account = (AccountID.fromParser(hopParser) as AccountID).toJSON();
     }
@@ -128,7 +130,7 @@ class Hop extends SerializedType {
     if (type & TYPE_ISSUER) {
       issuer = (AccountID.fromParser(hopParser) as AccountID).toJSON();
     }
-    
+
     return {
       account: account,
       issuer: issuer,

--- a/test/lower-case-hex.test.js
+++ b/test/lower-case-hex.test.js
@@ -1,0 +1,42 @@
+const { encode, decode } = require('../dist')
+
+let str = "1100612200000000240000000125000068652D0000000055B6632D6376A2D9319F20A1C6DCCB486432D1E4A79951229D4C3DE2946F51D56662400009184E72A00081140DD319918CD5AE792BF7EC80D63B0F01B4573BBC"
+let lower = str.toLowerCase();
+
+let bin = "1100612200000000240000000125000000082D00000000550735A0B32B2A3F4C938B76D6933003E29447DB8C7CE382BBE089402FF12A03E56240000002540BE400811479927BAFFD3D04A26096C0C97B1B0D45B01AD3C0"
+let json = {
+    "OwnerCount": 0,
+    "Account": "rUnFEsHjxqTswbivzL2DNHBb34rhAgZZZK",
+    "PreviousTxnLgrSeq": 8,
+    "LedgerEntryType": "AccountRoot",
+    "PreviousTxnID": "0735A0B32B2A3F4C938B76D6933003E29447DB8C7CE382BBE089402FF12A03E5".toLowerCase(),
+    "Flags": 0,
+    "Sequence": 1,
+    "Balance": "10000000000"
+  }
+  let jsonUpper = {
+    "OwnerCount": 0,
+    "Account": "rUnFEsHjxqTswbivzL2DNHBb34rhAgZZZK",
+    "PreviousTxnLgrSeq": 8,
+    "LedgerEntryType": "AccountRoot",
+    "PreviousTxnID": "0735A0B32B2A3F4C938B76D6933003E29447DB8C7CE382BBE089402FF12A03E5",
+    "Flags": 0,
+    "Sequence": 1,
+    "Balance": "10000000000"
+  }
+
+describe("Lowercase hex test", () => {
+    test("Correctly decodes", () => {
+        expect(decode(lower)).toEqual(decode(str))
+    })
+    test("Re-encodes to uppercase hex", () => {
+        expect(encode(decode(lower))).toEqual(str)
+    })
+    test("Encode when hex field lowercase", () => {
+        expect(encode(json)).toBe((bin))
+    })
+    test("Re-decodes to uppercase hex", () => {
+        expect(decode(encode(json))).toEqual(jsonUpper)
+    })
+})
+

--- a/test/lower-case-hex.test.js
+++ b/test/lower-case-hex.test.js
@@ -14,7 +14,7 @@ let json = {
     "Sequence": 1,
     "Balance": "10000000000"
   }
-  let jsonUpper = {
+let jsonUpper = {
     "OwnerCount": 0,
     "Account": "rUnFEsHjxqTswbivzL2DNHBb34rhAgZZZK",
     "PreviousTxnLgrSeq": 8,
@@ -33,7 +33,7 @@ describe("Lowercase hex test", () => {
         expect(encode(decode(lower))).toEqual(str)
     })
     test("Encode when hex field lowercase", () => {
-        expect(encode(json)).toBe((bin))
+        expect(encode(json)).toBe(bin)
     })
     test("Re-decodes to uppercase hex", () => {
         expect(decode(encode(json))).toEqual(jsonUpper)


### PR DESCRIPTION
## High Level Overview of Change
Added tests to show the library could parse lower-case hex strings.

### Context of Change
Added tests to verify that ripple-binary-codec could handle lower-case hex-strings. The library is able to parse lower-case hex due to the use of `Buffer`.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan
Show that in both encoding and decoding, the library supports parsing lowercase hex.