### PR TITLE
[0.2.x] Update GitHub Actions CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,11 +5,29 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ 0.2.x ]
   pull_request:
-    branches: [ master ]
+    branches: [ 0.2.x ]
 
 jobs:
+  build_with_nvm:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Read .nvmrc # From https://github.com/actions/setup-node/issues/32#issuecomment-525791142
+      run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+      id: nvm
+    - name: Use Node.js (.nvmrc)
+      uses: actions/setup-node@v1
+      with:
+        node-version: "${{ steps.nvm.outputs.NVMRC }}"
+    - run: yarn install
+    - run: yarn run test
+    - run: yarn run lint
+    - run: yarn run compile
+
   build:
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
There were a few minuscule updates made before the big refactor, so just to be safe, I'm going to do 1 last release of 0.2.x just in case anyone wants it.

One reason someone might want 0.2.x is if they can't or don't want to upgrade from Node.js 10.16 for example, and they don't need any new transaction types / features. Seems unusual, but plausible.