### PR TITLE
Filter undefined

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # ripple-binary-codec Release History
 
+## 1.0.1 (2020-09-08)
+- Filter out fields with undefined values
+
 ## 1.0.0 (2020-08-17)
 
 - Migrate to TypeScript

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Decode a hex-string into a transaction object.
 ```
 
 ### encode(json: object): string
-Encode a transaction object into a hex-string.
+Encode a transaction object into a hex-string. Note that encode filters out fields with undefined values.
 ```js
 > api.encode({
   LedgerEntryType: 'AccountRoot',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple-binary-codec",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "XRP Ledger binary codec",
   "files": [
     "dist/*",

--- a/src/enums/README.md
+++ b/src/enums/README.md
@@ -10,7 +10,7 @@ Each ledger's state tree contain [ledger objects](https://xrpl.org/ledger-object
 
 ## Fields
 
-These are Serialization Fields (`sf`) [defined in rippled's SField.cpp](https://github.com/ripple/rippled/blob/develop/src/ripple/protocol/impl/SField.cpp).
+These are Serialization Fields (`sf`) [defined in rippled's SField.cpp](https://github.com/ripple/rippled/blob/develop/src/ripple/protocol/impl/SField.cpp). Fields with undefined values are omitted before encoding.
 
 ### Key
 

--- a/src/types/st-object.ts
+++ b/src/types/st-object.ts
@@ -109,7 +109,12 @@ class STObject extends SerializedType {
 
     let sorted = Object.keys(xAddressDecoded)
       .map((f: string): FieldInstance => Field[f] as FieldInstance)
-      .filter((f: FieldInstance): boolean => f !== undefined && f.isSerialized)
+      .filter(
+        (f: FieldInstance): boolean =>
+          f !== undefined &&
+          xAddressDecoded[f.name] !== undefined &&
+          f.isSerialized
+      )
       .sort((a, b) => {
         return a.ordinal - b.ordinal;
       });

--- a/test/binary-serializer.test.js
+++ b/test/binary-serializer.test.js
@@ -50,6 +50,53 @@ const PaymentChannel = {
   },
 };
 
+let json_undefined = {
+  TakerPays: "223174650",
+  Account: "rPk2dXr27rMw9G5Ej9ad2Tt7RJzGy8ycBp",
+  TransactionType: "OfferCreate",
+  Memos: [
+    {
+      Memo: {
+        MemoType: "584D4D2076616C7565",
+        MemoData: "322E3230393635",
+        MemoFormat: undefined,
+      },
+    },
+  ],
+  Fee: "15",
+  OfferSequence: undefined,
+  TakerGets: {
+    currency: "XMM",
+    value: "100",
+    issuer: "rExAPEZvbkZqYPuNcZ7XEBLENEshsWDQc8",
+  },
+  Flags: 524288,
+  Sequence: undefined,
+  LastLedgerSequence: 6220135,
+};
+
+let json_omitted = {
+  TakerPays: "223174650",
+  Account: "rPk2dXr27rMw9G5Ej9ad2Tt7RJzGy8ycBp",
+  TransactionType: "OfferCreate",
+  Memos: [
+    {
+      Memo: {
+        MemoType: "584D4D2076616C7565",
+        MemoData: "322E3230393635",
+      },
+    },
+  ],
+  Fee: "15",
+  TakerGets: {
+    currency: "XMM",
+    value: "100",
+    issuer: "rExAPEZvbkZqYPuNcZ7XEBLENEshsWDQc8",
+  },
+  Flags: 524288,
+  LastLedgerSequence: 6220135,
+};
+
 const NegativeUNL = require("./fixtures/negative-unl.json");
 
 function bytesListTest() {
@@ -179,6 +226,15 @@ function NegativeUNLTest() {
   });
 }
 
+function omitUndefinedTest() {
+  test("omits fields with undefined value", () => {
+    let encodedOmitted = encode(json_omitted);
+    let encodedUndefined = encode(json_undefined);
+    expect(encodedOmitted).toEqual(encodedUndefined);
+    expect(decode(encodedOmitted)).toEqual(decode(encodedUndefined));
+  });
+}
+
 describe("Binary Serialization", function () {
   describe("nestedObjectTests", () => nestedObjectTests());
   describe("BytesList", () => bytesListTest());
@@ -188,4 +244,5 @@ describe("Binary Serialization", function () {
   describe("Escrow", () => EscrowTest());
   describe("PaymentChannel", () => PaymentChannelTest());
   describe("NegativeUNLTest", () => NegativeUNLTest());
+  describe("OmitUndefined", () => omitUndefinedTest());
 });


### PR DESCRIPTION
## High Level Overview of Change
Omit fields with undefined values when encoding.

### Context of Change
`xpring-common-js` has objects in the form 
```
{ Memo: {
    MemoData: undefined,
    .....
```
The change @amiecorso, @intelliot, and I decided on was to omit fields with undefined values.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan
Added a test with undefined values and compared to an encoding of an object with those values omitted.

