### PR TITLE
Encode any 3 character ASCII currency code

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # ripple-binary-codec Release History
 
+## 1.0.2 (2020-09-11)
+- Allow currencies to be encoded from any 3 Letter ASCII code.
+
 ## 1.0.1 (2020-09-08)
 - Filter out fields with undefined values
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,7 @@
 # ripple-binary-codec Release History
 
 ## 1.0.2 (2020-09-11)
-- Allow currencies to be encoded from any 3 Letter ASCII code.
+- Allow currencies to be encoded from any 3 character ASCII code.
 
 ## 1.0.1 (2020-09-08)
 - Filter out fields with undefined values

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ Encode a transaction object into a hex-string. Note that encode filters out fiel
   * If other fields (in the future) must to support X-addresses with tags, this library will need to be updated.
   * When decoding rippled binary, the output will always output classic address + tag, with no X-addresses. X-address support only applies when encoding to binary.
 
+#### Encoding Currencies
+  * ripple-binary-codec allows for any 3 Letter ASCII string to be encoded into a currency.
+  * ripple-binary-codec will decode currencies into that are valid ISO 4217 codes.
+  * If a currency is not a valid ISO 4217 code, it will return a 160-bit hex-string.
+
 ### encodeForSigning(json: object): string
 
 Encode the transaction object for signing.

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Encode a transaction object into a hex-string. Note that encode filters out fiel
   * If other fields (in the future) must to support X-addresses with tags, this library will need to be updated.
   * When decoding rippled binary, the output will always output classic address + tag, with no X-addresses. X-address support only applies when encoding to binary.
 
-#### Encoding Currencies
-  * ripple-binary-codec allows for any 3 Letter ASCII string to be encoded into a currency.
+#### Encoding Currency Codes
+  * ripple-binary-codec allows for any 3 character ASCII string to be encoded into a [currency code](https://xrpl.org/currency-formats.html#currency-codes).
   * ripple-binary-codec will decode currencies into that are valid ISO 4217 codes.
   * If a currency is not a valid ISO 4217 code, it will return a 160-bit hex-string.
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ Encode a transaction object into a hex-string. Note that encode filters out fiel
   * When decoding rippled binary, the output will always output classic address + tag, with no X-addresses. X-address support only applies when encoding to binary.
 
 #### Encoding Currency Codes
-  * ripple-binary-codec allows for any 3 character ASCII string to be encoded into a [currency code](https://xrpl.org/currency-formats.html#currency-codes).
-  * ripple-binary-codec will decode currencies into that are valid ISO 4217 codes.
-  * If a currency is not a valid ISO 4217 code, it will return a 160-bit hex-string.
+  * The standard format for currency codes is a three-letter string such as `USD`. This is intended for use with ISO 4217 Currency Codes.
+  * Currency codes must be exactly 3 ASCII characters in length and there are [a few other rules](https://xrpl.org/currency-formats.html#currency-codes).
+  * ripple-binary-codec allows any 3-character ASCII string to be encoded as a currency code, although rippled may enforce tighter restrictions.
+  * When _decoding_, if a currency code is three uppercase letters or numbers (`/^[A-Z0-9]{3}$/`), then it will be decoded into that string. For example,`0000000000000000000000004142430000000000` decodes as `ABC`.
+  * When decoding, if a currency code is does not match the regex, then it is not considered to be an ISO 4217 or pseudo-ISO currency. ripple-binary-codec will return a 160-bit hex-string (40 hex characters). For example, `0000000000000000000000006142430000000000` (`aBC`) decodes as `0000000000000000000000006142430000000000` because it contains a lowercase letter.
 
 ### encodeForSigning(json: object): string
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple-binary-codec",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "XRP Ledger binary codec",
   "files": [
     "dist/*",

--- a/src/types/currency.ts
+++ b/src/types/currency.ts
@@ -18,7 +18,7 @@ function isoToBytes(iso: string): Buffer {
  * Tests if ISO is a valid iso code
  */
 function isIsoCode(iso: string): boolean {
-  return ISO_REGEX.test(iso);
+  return iso.length === 3;
 }
 
 /**

--- a/test/hash.test.js
+++ b/test/hash.test.js
@@ -54,6 +54,20 @@ describe("Currency", function () {
     expect(bad.iso()).toBeUndefined();
     expect(bad.isNative()).toBe(false);
   });
+  test("Currency with lowercase letters decode to hex", () => {
+    expect(Currency.from("xRp").toJSON()).toBe(
+      "0000000000000000000000007852700000000000"
+    );
+  });
+  test("Currency codes with symbols decode to hex", () => {
+    expect(Currency.from("x|p").toJSON()).toBe(
+      "000000000000000000000000787C700000000000"
+    );
+  });
+  test("Currency codes with uppercase and 0-9 decode to ISO codes", () => {
+    expect(Currency.from("X8P").toJSON()).toBe("X8P");
+    expect(Currency.from("USD").toJSON()).toBe("USD");
+  });
   test("can be constructed from a Buffer", function () {
     const xrp = new Currency(Buffer.alloc(20));
     expect(xrp.iso()).toBe("XRP");


### PR DESCRIPTION
Allow for the encoding of all 3 letter ASCII currency codes.

Only decode into ASCII codes if they are valid ISO 4217 codes.