### PR TITLE
X-Address Encoding in Issued Currencies

### DIFF
--- a/src/types/account-id.ts
+++ b/src/types/account-id.ts
@@ -1,4 +1,9 @@
-import { decodeAccountID, encodeAccountID, isValidXAddress, xAddressToClassicAddress } from "ripple-address-codec";
+import {
+  decodeAccountID,
+  encodeAccountID,
+  isValidXAddress,
+  xAddressToClassicAddress,
+} from "ripple-address-codec";
 import { Hash160 } from "./hash-160";
 
 const HEX_REGEX = /^[A-F0-9]{40}$/;
@@ -45,12 +50,12 @@ class AccountID extends Hash160 {
    */
   static fromBase58(value: string): AccountID {
     if (isValidXAddress(value)) {
-      const classic = xAddressToClassicAddress(value)
+      const classic = xAddressToClassicAddress(value);
 
       if (classic.tag !== false)
-        throw new Error("Only allowed to have tag on Account or Destination")
+        throw new Error("Only allowed to have tag on Account or Destination");
 
-      value = classic.classicAddress
+      value = classic.classicAddress;
     }
 
     return new AccountID(Buffer.from(decodeAccountID(value)));

--- a/src/types/account-id.ts
+++ b/src/types/account-id.ts
@@ -1,4 +1,4 @@
-import { decodeAccountID, encodeAccountID } from "ripple-address-codec";
+import { decodeAccountID, encodeAccountID, isValidXAddress, xAddressToClassicAddress } from "ripple-address-codec";
 import { Hash160 } from "./hash-160";
 
 const HEX_REGEX = /^[A-F0-9]{40}$/;
@@ -44,7 +44,16 @@ class AccountID extends Hash160 {
    * @returns an AccountID object
    */
   static fromBase58(value: string): AccountID {
-    return new AccountID(decodeAccountID(value));
+    if (isValidXAddress(value)) {
+      const classic = xAddressToClassicAddress(value)
+
+      if (classic.tag !== false)
+        throw new Error("Only allowed to have tag on Account or Destination")
+
+      value = classic.classicAddress
+    }
+
+    return new AccountID(Buffer.from(decodeAccountID(value)));
   }
 
   /**

--- a/test/x-address.test.js
+++ b/test/x-address.test.js
@@ -96,28 +96,28 @@ let invalid_json_x_and_tagged = {
 };
 
 let json_issued_x = {
-  "TakerPays": {
-    "currency": "USD",
-    "issuer": "X7WZKEeNVS2p9Tire9DtNFkzWBZbFtJHWxDjN9fCrBGqVA4",
-    "value": "7072.8"
-  }
-}
+  TakerPays: {
+    currency: "USD",
+    issuer: "X7WZKEeNVS2p9Tire9DtNFkzWBZbFtJHWxDjN9fCrBGqVA4",
+    value: "7072.8",
+  },
+};
 
 let json_issued_r = {
-  "TakerPays": {
-    "currency": "USD",
-    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
-    "value": "7072.8"
-  }
-}
+  TakerPays: {
+    currency: "USD",
+    issuer: "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+    value: "7072.8",
+  },
+};
 
 let json_issued_with_tag = {
-  "TakerPays": {
-    "currency": "USD",
-    "issuer": "X7WZKEeNVS2p9Tire9DtNFkzWBZbFtSiS2eDBib7svZXuc2",
-    "value": "7072.8"
-  }
-}
+  TakerPays: {
+    currency: "USD",
+    issuer: "X7WZKEeNVS2p9Tire9DtNFkzWBZbFtSiS2eDBib7svZXuc2",
+    value: "7072.8",
+  },
+};
 
 describe("X-Address Account is equivalent to a classic address w/ SourceTag", () => {
   let encoded_x = encode(json_x1);
@@ -141,7 +141,7 @@ describe("X-Address Account is equivalent to a classic address w/ SourceTag", ()
 
   test("Encodes issued currency w/ x-address", () => {
     expect(encode(json_issued_x)).toEqual(encode(json_issued_r));
-  })
+  });
 });
 
 describe("Invalid X-Address behavior", () => {
@@ -158,8 +158,10 @@ describe("Invalid X-Address behavior", () => {
   });
 
   test("Throws when issued currency has tag", () => {
-    expect(() => encode(json_issued_with_tag)).toThrow("Only allowed to have tag on Account or Destination")
-  })
+    expect(() => encode(json_issued_with_tag)).toThrow(
+      "Only allowed to have tag on Account or Destination"
+    );
+  });
 });
 
 describe("ripple-binary-codec x-address test", function () {

--- a/test/x-address.test.js
+++ b/test/x-address.test.js
@@ -95,6 +95,30 @@ let invalid_json_x_and_tagged = {
   SourceTag: 12345,
 };
 
+let json_issued_x = {
+  "TakerPays": {
+    "currency": "USD",
+    "issuer": "X7WZKEeNVS2p9Tire9DtNFkzWBZbFtJHWxDjN9fCrBGqVA4",
+    "value": "7072.8"
+  }
+}
+
+let json_issued_r = {
+  "TakerPays": {
+    "currency": "USD",
+    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+    "value": "7072.8"
+  }
+}
+
+let json_issued_with_tag = {
+  "TakerPays": {
+    "currency": "USD",
+    "issuer": "X7WZKEeNVS2p9Tire9DtNFkzWBZbFtSiS2eDBib7svZXuc2",
+    "value": "7072.8"
+  }
+}
+
 describe("X-Address Account is equivalent to a classic address w/ SourceTag", () => {
   let encoded_x = encode(json_x1);
   let encoded_r = encode(json_r1);
@@ -114,6 +138,10 @@ describe("X-Address Account is equivalent to a classic address w/ SourceTag", ()
   test("Throws when X-Address is invalid", () => {
     expect(() => encode(json_invalid_x)).toThrow("checksum_invalid");
   });
+
+  test("Encodes issued currency w/ x-address", () => {
+    expect(encode(json_issued_x)).toEqual(encode(json_issued_r));
+  })
 });
 
 describe("Invalid X-Address behavior", () => {
@@ -128,6 +156,10 @@ describe("Invalid X-Address behavior", () => {
       new Error("Cannot have Account X-Address and SourceTag")
     );
   });
+
+  test("Throws when issued currency has tag", () => {
+    expect(() => encode(json_issued_with_tag)).toThrow("Only allowed to have tag on Account or Destination")
+  })
 });
 
 describe("ripple-binary-codec x-address test", function () {


### PR DESCRIPTION
## High Level Overview of Change
Handle the case when issued currencies have an X-address in the issuer. 

### Context of Change
We handle the two cases where X addresses can have destination tags in `STObject`. For the rest of the `AccountIDs`, if we receive an X address then it cannot have a tag associated with it. This PR implements this functionality in the `AccountID::fromBase58`

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan
Adds two tests to test this functionality