### PR TITLE
fix typo in the text of exception

### DIFF
--- a/src/types/st-array.ts
+++ b/src/types/st-array.ts
@@ -68,7 +68,7 @@ class STArray extends SerializedType {
       return new STArray(Buffer.concat(bytes));
     }
 
-    throw new Error("Cannot construct Currency from value given");
+    throw new Error("Cannot construct STArray from value given");
   }
 
   /**


### PR DESCRIPTION
As title says, "Currency" -> "STArray" in types/st-array.ts.

(<s>maybe "Array" should better be used in the text of the human-readable exception message...</s>)