### PR TITLE
fix(path-set): do not return undefined values in toJSON function #117

### DIFF
--- a/src/types/path-set.ts
+++ b/src/types/path-set.ts
@@ -117,26 +117,20 @@ class Hop extends SerializedType {
     const hopParser = new BinaryParser(this.bytes.toString("hex"));
     const type = hopParser.readUInt8();
 
-    let account,
-      currency,
-      issuer: string | undefined = undefined;
+    const result: HopObject = {};
     if (type & TYPE_ACCOUNT) {
-      account = (AccountID.fromParser(hopParser) as AccountID).toJSON();
+      result.account = (AccountID.fromParser(hopParser) as AccountID).toJSON();
     }
 
     if (type & TYPE_CURRENCY) {
-      currency = (Currency.fromParser(hopParser) as Currency).toJSON();
+      result.currency = (Currency.fromParser(hopParser) as Currency).toJSON();
     }
 
     if (type & TYPE_ISSUER) {
-      issuer = (AccountID.fromParser(hopParser) as AccountID).toJSON();
+      result.issuer = (AccountID.fromParser(hopParser) as AccountID).toJSON();
     }
 
-    return {
-      account: account,
-      issuer: issuer,
-      currency: currency,
-    };
+    return result;
   }
 
   /**


### PR DESCRIPTION
## High Level Overview of Change

Return value of method `toJSON` in `Hop` class in `path-set.ts` was changed to include only defined values.

### Context of Change

Refactoring Hop, Path, and PathSet to extends serialized type and constructor parameters to be of type Buffer, to match how the base class is constructed. Moved from makeClass() -> class.
### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

### Before:
`toJSON` method returnes undefined values. Undefined value is not a valid json value per [official JSON standard](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf) (ECMA-404, Section 5).

> A JSON value can be an object, array, number, string, true, false, or null.

This issue also causes regression in ripple-lib as described in #117.

### After:
Revert https://github.com/ripple/ripple-binary-codec/pull/96/files#diff-b819aca034c388228b6db529f7fa97223e2294ff6036f5f9f7bdadd1d793c1eaL115

Return only defined values. If value is undefined simply do not return it. It will still be undefined :)

## Test Plan
No tests added.