### PR TITLE
chore: update HISTORY.md and version

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # ripple-binary-codec Release History
 
+## 1.1.1 (2021-02-12)
+- PathSet.toJSON() does not return undefined values
+- Add support for X-Addresses in Issued Currency Amounts
+- Fix STArray error message
+
 ## 1.1.0 (2020-12-03)
 - Add support for Tickets (TicketBatch amendment)
 - Fix web browser compatibility

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple-binary-codec",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "XRP Ledger binary codec",
   "files": [
     "dist/*",


### PR DESCRIPTION
Preparation for `v1.1.1` release. Updates `HISTORY.md` + `package.json` version.