### PR TITLE
build: Release 1.1.2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # ripple-binary-codec Release History
 
+## 1.1.2 (2021-03-10)
+- Fix for case UInt64.from string '0'
+
 ## 1.1.1 (2021-02-12)
 - PathSet.toJSON() does not return undefined values
 - Add support for X-Addresses in Issued Currency Amounts

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,7 @@
 # ripple-binary-codec Release History
 
 ## 1.1.2 (2021-03-10)
-- Fix for case UInt64.from string '0'
+- Fix for case UInt64.from string '0' due to changes in rippled 1.7.0
 
 ## 1.1.1 (2021-02-12)
 - PathSet.toJSON() does not return undefined values

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple-binary-codec",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "XRP Ledger binary codec",
   "files": [
     "dist/*",


### PR DESCRIPTION
Prepare `ripple-binary-codec` for version 1.1.2. Modifies `History.md` and bumps package.json version to 1.1.2