### PR TITLE
fix: change sfValidatorToReEnable to field code 21

### DIFF
--- a/src/enums/definitions.json
+++ b/src/enums/definitions.json
@@ -1047,7 +1047,7 @@
     [
       "ValidatorToReEnable",
       {
-        "nth": 20,
+        "nth": 21,
         "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,


### PR DESCRIPTION
## High Level Overview of Change
Corrects field code for `sfValidatorToReEnable`.
fixes #127 

### Context of Change
Field code for `sfValidatorToReEnable` should be 21. See https://github.com/ripple/rippled/blob/develop/src/ripple/protocol/impl/SField.cpp/#L227

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

Note: I am personally of the opinion that this can wait to go into the next release, and does not merit its own re-release, as negativeUNL has not been enabled on mainnet yet. Open to other opinions from reviewers.
