### PR TITLE
chore: prepare for 1.1.3 release

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,8 @@
 # ripple-binary-codec Release History
 
 ## 1.1.3 (2021-06-11)
-- Fix for case UInt64.from string allowing lowercase hex
-- Fix for `ValidatorToReEnable` field code
+- Fix for case UInt64.from string allowing lowercase hex (#135)
+- Fix for `ValidatorToReEnable` field code (#130)
 
 ## 1.1.2 (2021-03-10)
 - Fix for case UInt64.from string '0' due to changes in rippled 1.7.0

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # ripple-binary-codec Release History
 
+## 1.1.2 (2021-06-11)
+- Fix for case UInt64.from string allowing lowercase hex
+- Fix for `ValidatorToReEnable` field code
+
 ## 1.1.2 (2021-03-10)
 - Fix for case UInt64.from string '0' due to changes in rippled 1.7.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # ripple-binary-codec Release History
 
-## 1.1.2 (2021-06-11)
+## 1.1.3 (2021-06-11)
 - Fix for case UInt64.from string allowing lowercase hex
 - Fix for `ValidatorToReEnable` field code
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple-binary-codec",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "XRP Ledger binary codec",
   "files": [
     "dist/*",


### PR DESCRIPTION
Chore for releasing `ripple-binary-codec@1.1.3`

Updates `package.json` + `HISTORY.md`